### PR TITLE
Makefile changes and e e

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,18 @@
 CC=gcc
 CFLAGS=-Wall -Werror -Wextra -std=gnu11 -ggdb3
 LINK=-lncurses
+# export CONFIG_SRC=/path/to/config.c in your environment to build your own ce_config.so
+CONFIG_SRC?=ce_config.c
+
+all: ce ce_config.so
 
 ce: main.c ce.o
 	$(CC) $(CFLAGS) $^ -o $@ $(LINK) -ldl -Wl,-rpath=.
 
-j: CONFIG_SRC=j_ce_config.c
-j: ce_config.so
-b: CONFIG_SRC=b_ce_config.c
-b: ce_config.so
-
 ce.o: ce.c
 	$(CC) -c -fpic $(CFLAGS) $^ -o $@
 
-ce_config.o: ce_config.c
+ce_config.o: $(CONFIG_SRC)
 	$(CC) -c -fpic $(CFLAGS) $^ -o $@
 
 ce_config.so: ce_config.o ce.o

--- a/ce_config.c
+++ b/ce_config.c
@@ -49,7 +49,7 @@ static void advance_to_boundary(Buffer* buffer, Point* cursor, const char* bound
           if(boundary_char){
                if(boundary_char == search_char){
                     cursor->x++;
-                    advance_to_boundary(buffer, cursor, boundary_str );
+                    advance_to_boundary(buffer, cursor, boundary_str);
                }
                else{
                     cursor->x += (boundary_char--) - search_char;

--- a/ce_config.c
+++ b/ce_config.c
@@ -1,4 +1,5 @@
 #include "ce.h"
+#include "assert.h"
 
 bool g_insert = false;
 bool g_split = false;
@@ -32,6 +33,36 @@ bool destroyer(BufferNode* head)
      }
 
      return true;
+}
+
+const char* weak_word_boundary_characters = " [](){}+->.,=!?\"'";
+const char* strong_word_boundary_characters = " ";
+// move cursor to next word boundary
+static void advance_to_boundary(Buffer* buffer, Point* cursor, const char* boundary_str) {
+     if(buffer->lines[cursor->y][0] == '\0') return;
+     const char* search_char = &buffer->lines[cursor->y][cursor->x+1];
+     assert(cursor->x <= (int64_t)strlen(buffer->lines[cursor->y]));
+     if(search_char != '\0'){
+          // search for a word boundary character after our current character
+          const char* boundary_char = strpbrk(search_char, boundary_str);
+          if(boundary_char){
+               if(boundary_char == search_char){
+                    cursor->x++;
+                    advance_to_boundary(buffer, cursor, boundary_str );
+               }
+               else{
+                    cursor->x += (boundary_char--) - search_char;
+               }
+               // we end at the character before the boundary
+               // character if we did not start at a word boundary,
+               // or the last boundary character if we started at a word boundary
+               return;
+          }
+          else {
+               cursor->x = strlen(buffer->lines[cursor->y])-1;
+               return;
+          }
+     }
 }
 
 bool key_handler(int key, BufferNode* head)
@@ -118,6 +149,14 @@ bool key_handler(int key, BufferNode* head)
                }else{
                     cursor->x = 0;
                }
+          } break;
+          case 'e':
+          {
+               advance_to_boundary(buffer, cursor, weak_word_boundary_characters);
+          } break;
+          case 'E':
+          {
+               advance_to_boundary(buffer, cursor, strong_word_boundary_characters);
           } break;
           case 'h':
           if(cursor->x > 0){


### PR DESCRIPTION
Branch permissions won't let me push to master.

The makefile in place wasn't working correctly. It was assigning CONFIG_SRC as a target specific variable which doesn't get propagated to the ce_config.o target. Until we find a better way, I modified the makefile to build whichever CONFIG_SRC is defined in the user's environment.
- in bash `export CONFIG_SRC=/path/to/ce_config.c` then future makes will use that config

Also added initial implementation for `e` and `E` vim-like movement. These movements will need to be enhanced in the future to correctly handle a sequence of word boundary characters like vim does. For example if you hit `e` with `text<cursor_here>   ]]) more_text` vim would put your cursor on the last non-space word boundary character `)`. My initial implementation doesn't support this.

@justy989 feel free to change anything I write whenever you want if you have a better or cleaner way of doing things. I won't be offended!
