### PR TITLE
Implement some random cleanup items

### DIFF
--- a/ce.c
+++ b/ce.c
@@ -545,7 +545,7 @@ bool ce_find_match(const Buffer* buffer, const Point* location, Point* match)
      if(!ce_find_delta_to_match(buffer, location, &delta)) return false;
 
      *match = *location;
-     ce_move_cursor(buffer, match, &delta);
+     ce_move_cursor(buffer, match, delta);
 
      return true;
 }
@@ -1392,17 +1392,15 @@ bool ce_remove_buffer_from_list(BufferNode* head, BufferNode** node)
      return false;
 }
 
-// return x delta to the last character in the line, -1 on error
-int64_t ce_find_delta_to_end_of_line(const Buffer* buffer, const Point* cursor)
+bool ce_move_cursor_to_end_of_line(const Buffer* buffer, Point* cursor)
 {
      CE_CHECK_PTR_ARG(buffer);
      CE_CHECK_PTR_ARG(cursor);
 
-     if(!ce_point_on_buffer(buffer, cursor)) return -1;
+     if(!ce_point_on_buffer(buffer, cursor)) return false;
 
-     const char* line = buffer->lines[cursor->y];
-     size_t len = strlen(line);
-     return len ? (len - 1) - cursor->x : 0;
+     cursor->x = strlen(buffer->lines[cursor->y]); 
+     return true;
 }
 
 bool ce_set_cursor(const Buffer* buffer, Point* cursor, const Point* location)
@@ -1436,20 +1434,18 @@ bool ce_set_cursor(const Buffer* buffer, Point* cursor, const Point* location)
 
 // modifies cursor and also returns a pointer to cursor for convience
 Point* ce_clamp_cursor(const Buffer* buffer, Point* cursor){
-     Point clamp = {0, 0};
-     ce_move_cursor(buffer, cursor, &clamp);
+     ce_move_cursor(buffer, cursor, (Point){0,0});
      return cursor;
 }
 
-bool ce_move_cursor(const Buffer* buffer, Point* cursor, const Point* delta)
+bool ce_move_cursor(const Buffer* buffer, Point* cursor, Point delta)
 {
      CE_CHECK_PTR_ARG(buffer);
      CE_CHECK_PTR_ARG(cursor);
-     CE_CHECK_PTR_ARG(delta);
 
      Point dst = *cursor;
-     dst.x += delta->x;
-     dst.y += delta->y;
+     dst.x += delta.x;
+     dst.y += delta.y;
 
      if(dst.x < 0) dst.x = 0;
      if(dst.y < 0) dst.y = 0;

--- a/ce.h
+++ b/ce.h
@@ -191,7 +191,6 @@ int64_t ce_get_indentation_for_next_line (const Buffer* buffer, const Point* loc
 
 
 // Find Delta Functions
-int64_t ce_find_delta_to_end_of_line            (const Buffer* buffer, const Point* location);
 int64_t ce_find_delta_to_soft_end_of_line       (const Buffer* buffer, const Point* location);
 int64_t ce_find_delta_to_soft_beginning_of_line (const Buffer* buffer, const Point* location);
 int64_t ce_find_delta_to_char_forward_in_line   (const Buffer* buffer, const Point* location, char c);
@@ -211,8 +210,9 @@ bool ce_get_homogenous_adjacents (const Buffer* buffer, Point* start, Point* end
 // Cursor Movement Functions
 Point* ce_clamp_cursor                          (const Buffer* buffer, Point* cursor);
 bool   ce_advance_cursor                        (const Buffer* buffer, Point* cursor, int64_t delta);
-bool   ce_move_cursor                           (const Buffer* buffer, Point* cursor, const Point* delta);
+bool   ce_move_cursor                           (const Buffer* buffer, Point* cursor, Point delta);
 bool   ce_set_cursor                            (const Buffer* buffer, Point* cursor, const Point* location);
+bool   ce_move_cursor_to_end_of_line            (const Buffer* buffer, Point* cursor);
 bool   ce_move_cursor_to_soft_end_of_line       (const Buffer* buffer, Point* cursor);
 bool   ce_move_cursor_to_soft_beginning_of_line (const Buffer* buffer, Point* cursor);
 bool   ce_move_cursor_to_end_of_file            (const Buffer* buffer, Point* cursor);

--- a/ce_config.c
+++ b/ce_config.c
@@ -470,31 +470,27 @@ void find_command(int command_key, int find_char, Buffer* buffer, Point* cursor)
      {
           int64_t x_delta = ce_find_delta_to_char_forward_in_line(buffer, cursor, find_char);
           if(x_delta == -1) break;
-          Point delta = {x_delta, 0};
-          ce_move_cursor(buffer, cursor, &delta);
+          ce_move_cursor(buffer, cursor, (Point){x_delta, 0});
      } break;
      case 't':
      {
           Point search_point = {cursor->x + 1, cursor->y};
           int64_t x_delta = ce_find_delta_to_char_forward_in_line(buffer, &search_point, find_char);
           if(x_delta <= 0) break;
-          Point delta = {x_delta, 0};
-          ce_move_cursor(buffer, cursor, &delta);
+          ce_move_cursor(buffer, cursor, (Point){x_delta, 0});
      } break;
      case 'F':
      {
           int64_t x_delta = ce_find_delta_to_char_backward_in_line(buffer, cursor, find_char);
           if(x_delta == -1) break;
-          Point delta = {-x_delta, 0};
-          ce_move_cursor(buffer, cursor, &delta);
+          ce_move_cursor(buffer, cursor, (Point){-x_delta, 0});
      } break;
      case 'T':
      {
           Point search_point = {cursor->x - 1, cursor->y};
           int64_t x_delta = ce_find_delta_to_char_backward_in_line(buffer, &search_point, find_char);
           if(x_delta <= 0) break;
-          Point delta = {-x_delta, 0};
-          ce_move_cursor(buffer, cursor, &delta);
+          ce_move_cursor(buffer, cursor, (Point){-x_delta, 0});
      } break;
      default:
           assert(0);
@@ -546,26 +542,23 @@ movement_state_t try_generic_movement(ConfigState* config_state, Buffer* buffer,
           case KEY_LEFT:
           case 'h':
           {
-               Point delta = {-1, 0};
-               ce_move_cursor(buffer, movement_end, &delta);
+               ce_move_cursor(buffer, movement_end, (Point){-1, 0});
           } break;
           case KEY_DOWN:
           case 'j':
           {
-               Point delta = {0, 1};
-               ce_move_cursor(buffer, movement_end, &delta);
+               *movement_start = (Point){0, cursor->y};
+               ce_move_cursor(buffer, movement_end, (Point){0, 1});
           } break;
           case KEY_UP:
           case 'k':
           {
-               Point delta = {0, -1};
-               ce_move_cursor(buffer, movement_end, &delta);
+               ce_move_cursor(buffer, movement_end, (Point){0, -1});
           } break;
           case KEY_RIGHT:
           case 'l':
           {
-               Point delta = {1, 0};
-               ce_move_cursor(buffer, movement_end, &delta);
+               ce_move_cursor(buffer, movement_end, (Point){1, 0});
           } break;
           case '0':
           {
@@ -734,7 +727,7 @@ movement_state_t try_generic_movement(ConfigState* config_state, Buffer* buffer,
                movement_end->x += ce_find_delta_to_next_word(buffer, movement_end, key0 == 'w');
                break;
           case '$':
-               movement_end->x += ce_find_delta_to_end_of_line(buffer, movement_end);
+               ce_move_cursor_to_end_of_line(buffer, movement_end);
                break;
           case '%':
           {
@@ -757,8 +750,7 @@ movement_state_t try_generic_movement(ConfigState* config_state, Buffer* buffer,
           case 'G':
           {
                ce_move_cursor_to_end_of_file(buffer, movement_end);
-               Point delta = {ce_find_delta_to_end_of_line(buffer, movement_end), 0};
-               ce_move_cursor(buffer, movement_end, &delta);
+               ce_move_cursor_to_end_of_line(buffer, movement_end);
           } break;
           case 'g':
                switch(key1){
@@ -892,8 +884,7 @@ bool key_handler(int key, BufferNode* head, void* user_data)
           case '\t':
           {
                ce_insert_string(buffer, cursor, TAB_STRING);
-               Point delta = {5, 0};
-               ce_move_cursor(buffer, cursor, &delta);
+               ce_move_cursor(buffer, cursor, (Point){5, 0});
           } break;
           case 10: // return
           {
@@ -940,24 +931,20 @@ bool key_handler(int key, BufferNode* head, void* user_data)
 #if 0
           case 8: // Ctrl + h
           {
-               Point delta = {-1, 0};
-               ce_move_cursor(buffer, cursor, &delta);
+               ce_move_cursor(buffer, cursor, (Point){-1, 0});
           } break;
           // NOTE: NOOOOO Ctrl + j == Ctrl + m == Return... WHY IS EVERYTHING SO TERRIBLE!
           case 10: // Ctrl + j
           {
-               Point delta = {0, 1};
-               ce_move_cursor(buffer, cursor, &delta);
+               ce_move_cursor(buffer, cursor, (Point){0, 1});
           } break;
           case 11: // Ctrl + k
           {
-               Point delta = {0, -1};
-               ce_move_cursor(buffer, cursor, &delta);
+               ce_move_cursor(buffer, cursor, (Point){0, -1});
           } break;
           case 12: // Ctrl + l
           {
-               Point delta = {1, 0};
-               ce_move_cursor(buffer, cursor, &delta);
+               ce_move_cursor(buffer, cursor, (Point){1, 0});
           } break;
 #endif
           case '}':
@@ -1195,8 +1182,10 @@ bool key_handler(int key, BufferNode* head, void* user_data)
           } break;
           case 'A':
           {
-               cursor->x += ce_find_delta_to_end_of_line(buffer, cursor) + 1;
-               enter_insert_mode(config_state, cursor);
+               if(ce_move_cursor_to_end_of_line(buffer, cursor)){
+                    cursor->x++;
+                    enter_insert_mode(config_state, cursor);
+               }
           } break;
           case 'm':
           {
@@ -1288,26 +1277,13 @@ bool key_handler(int key, BufferNode* head, void* user_data)
                     }
                }
           } break;
-          case 'S':
-          {
-               // TODO: unify with cc
-               ce_move_cursor_to_soft_beginning_of_line(buffer, cursor);
-               int64_t n_deletes = ce_find_delta_to_end_of_line(buffer, cursor) + 1;
-               Point delete_end = {cursor->x + n_deletes, cursor->y};
-               char* save_string = ce_dupe_string(buffer, cursor, &delete_end);
-               if(ce_remove_string(buffer, cursor, n_deletes)){
-                    ce_commit_remove_string(&buffer_state->commit_tail, cursor, cursor, cursor, save_string);
-                    add_yank(config_state, '"', strdup(save_string), YANK_NORMAL);
-               }
-               enter_insert_mode(config_state, cursor);
-          } break;
           case 'C':
           case 'D':
           {
-               int64_t n_deletes = ce_find_delta_to_end_of_line(buffer, cursor) + 1;
+               Point end = *cursor;
+               ce_move_cursor_to_end_of_line(buffer, &end);
+               int64_t n_deletes = strlen(&buffer->lines[cursor->y][cursor->x]);
                if(n_deletes){
-                    Point end = *cursor;
-                    end.x += n_deletes;
                     char* save_string = ce_dupe_string(buffer, cursor, &end);
                     if(ce_remove_string(buffer, cursor, n_deletes)){
                          ce_commit_remove_string(&buffer_state->commit_tail, cursor, cursor, cursor, save_string);
@@ -1316,6 +1292,12 @@ bool key_handler(int key, BufferNode* head, void* user_data)
                }
                if(key == 'C') enter_insert_mode(config_state, cursor);
           } break;
+          case 'S':
+          {
+               config_state->movement_multiplier = 1;
+               config_state->movement_keys[0] = 'c';
+               config_state->command_key = 'c';
+          } // fall through to 'cc'
           case 'c':
           case 'd':
           {
@@ -1334,8 +1316,7 @@ bool key_handler(int key, BufferNode* head, void* user_data)
                                    break;
                               case 'd':
                               {
-                                   Point delta = {-cursor->x, 0};
-                                   ce_move_cursor(buffer, cursor, &delta);
+                                   ce_move_cursor(buffer, cursor, (Point){-cursor->x, 0});
                                    movement_start = (Point) {0, cursor->y};
                                    movement_end = (Point) {strlen(buffer->lines[cursor->y])+1, cursor->y}; // TODO: causes ce_dupe_string to fail (not on buffer)
                                    yank_mode = YANK_LINE;
@@ -1626,20 +1607,20 @@ bool key_handler(int key, BufferNode* head, void* user_data)
           {
                Point delta;
                if(ce_find_delta_to_match(buffer, cursor, &delta)){
-                    ce_move_cursor(buffer, cursor, &delta);
+                    ce_move_cursor(buffer, cursor, delta);
                }
           } break;
           case 21: // Ctrl + d
           {
                int64_t view_height = config_state->view_current->bottom_right.y - config_state->view_current->top_left.y;
                Point delta = {0, -view_height / 2};
-               ce_move_cursor(buffer, cursor, &delta);
+               ce_move_cursor(buffer, cursor, delta);
           } break;
           case 4: // Ctrl + u
           {
                int64_t view_height = config_state->view_current->bottom_right.y - config_state->view_current->top_left.y;
                Point delta = {0, view_height / 2};
-               ce_move_cursor(buffer, cursor, &delta);
+               ce_move_cursor(buffer, cursor, delta);
           } break;
           case 8: // Ctrl + h
           {

--- a/test.c
+++ b/test.c
@@ -896,8 +896,7 @@ TEST(sanity_move_cursor)
      buffer.lines[2] = strdup("AWESOME");
 
      Point cursor = {2, 0};
-     Point delta = {2, 1};
-     ce_move_cursor(&buffer, &cursor, &delta);
+     ce_move_cursor(&buffer, &cursor, (Point){2, 1});
 
      EXPECT(cursor.x == 4);
      EXPECT(cursor.y == 1);
@@ -1403,7 +1402,8 @@ TEST(sanity_split_view)
      }
 }
 
-TEST(sanity_find_delta_to_end_of_line)
+// TODO: this function should point us to the last character. not the newline.
+TEST(sanity_move_cursor_to_end_of_line)
 {
      Buffer buffer = {};
      buffer.line_count = 1;
@@ -1413,10 +1413,14 @@ TEST(sanity_find_delta_to_end_of_line)
      Point cursor;
 
      cursor = (Point) {0, 0};
-     ASSERT(ce_find_delta_to_end_of_line(&buffer, &cursor) == (int64_t) strlen(buffer.lines[0]) - 1);
+     ce_move_cursor_to_end_of_line(&buffer, &cursor);
+     ASSERT(cursor.x == (int64_t) strlen(buffer.lines[0]));
+     ASSERT(cursor.y == 0);
 
      cursor = (Point) {5, 0};
-     ASSERT(ce_find_delta_to_end_of_line(&buffer, &cursor) == (int64_t) strlen(buffer.lines[0]) - 1 - 5);
+     ce_move_cursor_to_end_of_line(&buffer, &cursor);
+     ASSERT(cursor.x == (int64_t) strlen(buffer.lines[0]));
+     ASSERT(cursor.y == 0);
 }
 
 TEST(sanity_ce_memrchr)


### PR DESCRIPTION
- ce_move_cursor now takes a delta by-value
- ce_find_delta_to_end_of_line is now ce_move_cursor_to_end_of_line
  NOTE: still need to fix implementation so this function points to the last char in a line
- Fix 'C' and 'D'
- Unify 'S' with 'cc'
