### PR TITLE
Keypad + backspace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CC?=clang
-CFLAGS+=-Wall -Werror -Wextra -std=c11 -ggdb3 -D_GNU_SOURCE
+CFLAGS+=-Wall -Werror -Wextra -std=c11 -ggdb3 -D_GNU_SOURCE $(SCROLL_FLAG)
 LINK=-lncurses
 
 all: ce ce_config.so

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CC?=clang
-CFLAGS=-Wall -Werror -Wextra -std=c11 -ggdb3 -D_GNU_SOURCE
+CFLAGS+=-Wall -Werror -Wextra -std=c11 -ggdb3 -D_GNU_SOURCE
 LINK=-lncurses
 
 all: ce ce_config.so

--- a/ce.h
+++ b/ce.h
@@ -247,7 +247,8 @@ void ce_is_string_literal(const char* line, int64_t start_offset, int64_t line_l
 int64_t ce_is_caps_var(const char* line, int64_t start_offset);
 
 // Logging Functions
-#define ce_message(...) fprintf(stderr,__VA_ARGS__); fprintf(stderr,"\n");
+#define ce_message(...) ({fprintf(stderr,__VA_ARGS__);\
+                          fprintf(stderr,"\n");})
 
 // Misc. Utility Functions
 int64_t ce_count_string_lines (const char* string);

--- a/ce_config.c
+++ b/ce_config.c
@@ -874,7 +874,12 @@ bool key_handler(int key, BufferNode* head, void* user_data)
                if(getmouse(&event) == OK){
                     if(event.bstate & BUTTON1_PRESSED){
                          Point click = {event.x, event.y};
-                         ce_set_cursor(buffer, cursor, &click);
+                         config_state->view_current = ce_find_view_at_point(config_state->view_head, &click);
+                         click = (Point) {event.x - (config_state->view_current->top_left.x - config_state->view_current->left_column),
+                                          event.y - config_state->view_current->top_left.y};
+                         ce_set_cursor(config_state->view_current->buffer_node->buffer,
+                                       &config_state->view_current->cursor,
+                                       &click);
                     }
                }
           } break;
@@ -1107,7 +1112,12 @@ bool key_handler(int key, BufferNode* head, void* user_data)
                if(getmouse(&event) == OK){
                     if(event.bstate & BUTTON1_PRESSED){
                          Point click = {event.x, event.y};
-                         ce_set_cursor(buffer, cursor, &click);
+                         config_state->view_current = ce_find_view_at_point(config_state->view_head, &click);
+                         click = (Point) {event.x - (config_state->view_current->top_left.x - config_state->view_current->left_column),
+                                          event.y - (config_state->view_current->top_left.y - config_state->view_current->top_row)};
+                         ce_set_cursor(config_state->view_current->buffer_node->buffer,
+                                       &config_state->view_current->cursor,
+                                       &click);
                     }
                }
           } break;

--- a/ce_config.c
+++ b/ce_config.c
@@ -876,7 +876,7 @@ bool key_handler(int key, BufferNode* head, void* user_data)
                          Point click = {event.x, event.y};
                          config_state->view_current = ce_find_view_at_point(config_state->view_head, &click);
                          click = (Point) {event.x - (config_state->view_current->top_left.x - config_state->view_current->left_column),
-                                          event.y - config_state->view_current->top_left.y};
+                                          event.y - (config_state->view_current->top_left.y - config_state->view_current->top_row)};
                          ce_set_cursor(config_state->view_current->buffer_node->buffer,
                                        &config_state->view_current->cursor,
                                        &click);
@@ -1118,6 +1118,10 @@ bool key_handler(int key, BufferNode* head, void* user_data)
                          ce_set_cursor(config_state->view_current->buffer_node->buffer,
                                        &config_state->view_current->cursor,
                                        &click);
+                    }else if(event.bstate & REPORT_MOUSE_POSITION){
+                         Point scroll_location = {0, buffer_view->top_row + 1};
+                         scroll_view_to_location(buffer_view, &scroll_location);
+                         if(buffer_view->cursor.y <= buffer_view->top_row) buffer_view->cursor.y++;
                     }
                }
           } break;

--- a/ce_config.c
+++ b/ce_config.c
@@ -1258,7 +1258,8 @@ void handle_mouse_event(ConfigState* config_state, Buffer* buffer, BufferState* 
           (void) buffer;
           (void) buffer_view;
 #endif
-          if(enter_insert) enter_insert_mode(config_state, cursor);
+          // if we left insert and haven't switched views, enter insert mode
+          if(enter_insert && config_state->view_current == buffer_view) enter_insert_mode(config_state, cursor);
      }
 }
 

--- a/ce_config.c
+++ b/ce_config.c
@@ -862,7 +862,7 @@ bool key_handler(int key, BufferNode* head, void* user_data)
                // when we exit insert mode, do not move the cursor back unless we are at the end of the line
                *cursor = end_cursor;
           } break;
-          case 127: // backspace
+          case KEY_BACKSPACE:
                if(buffer->line_count){
                     if(cursor->x <= 0){
                          if(cursor->y){

--- a/ce_config.c
+++ b/ce_config.c
@@ -1109,38 +1109,7 @@ void handle_mouse_event(ConfigState* config_state, Buffer* buffer, BufferView* b
 {
      MEVENT event;
      if(getmouse(&event) == OK){
-#ifndef MOUSE_DIAG
-          if(event.bstate & BUTTON1_PRESSED){ // Left click OSX
-               Point click = {event.x, event.y};
-               config_state->view_current = ce_find_view_at_point(config_state->view_head, &click);
-               click = (Point) {event.x - (config_state->view_current->top_left.x - config_state->view_current->left_column),
-                                event.y - (config_state->view_current->top_left.y - config_state->view_current->top_row)};
-               ce_set_cursor(config_state->view_current->buffer_node->buffer,
-                             &config_state->view_current->cursor,
-                             &click);
-          }else if(event.bstate & (REPORT_MOUSE_POSITION | BUTTON2_PRESSED)){ // Scroll down OSX (alternates between these two flags)
-               Point next_line = {0, cursor->y + SCROLL_LINES};
-               if(ce_point_on_buffer(buffer, &next_line)){
-                    Point scroll_location = {0, buffer_view->top_row + SCROLL_LINES};
-                    scroll_view_to_location(buffer_view, &scroll_location);
-                    if(buffer_view->cursor.y < buffer_view->top_row)
-                         ce_move_cursor(buffer, cursor, (Point){0, SCROLL_LINES});
-               }
-          }else if(event.bstate & BUTTON4_PRESSED){ // Scroll up OSX
-               Point next_line = {0, cursor->y - SCROLL_LINES};
-               if(ce_point_on_buffer(buffer, &next_line)){
-                    Point scroll_location = {0, buffer_view->top_row - SCROLL_LINES};
-                    scroll_view_to_location(buffer_view, &scroll_location);
-                    if(buffer_view->cursor.y > buffer_view->top_row + (buffer_view->bottom_right.y - buffer_view->top_left.y))
-                         ce_move_cursor(buffer, cursor, (Point){0, -SCROLL_LINES});
-               }
-          }
-#else
-          (void) config_state;
-          (void) buffer;
-          (void) buffer_view;
-          (void) cursor;
-
+#ifdef MOUSE_DIAG
           ce_message("0x%x", event.bstate);
           if(event.bstate & BUTTON1_PRESSED)
                ce_message("%s", "BUTTON1_PRESSED");
@@ -1192,6 +1161,39 @@ void handle_mouse_event(ConfigState* config_state, Buffer* buffer, BufferView* b
                ce_message("%s", "REPORT_MOUSE_POSITION");
           else if(event.bstate & ALL_MOUSE_EVENTS)
                ce_message("%s", "ALL_MOUSE_EVENTS");
+#endif
+          if(event.bstate & BUTTON1_PRESSED){ // Left click OSX
+               Point click = {event.x, event.y};
+               config_state->view_current = ce_find_view_at_point(config_state->view_head, &click);
+               click = (Point) {event.x - (config_state->view_current->top_left.x - config_state->view_current->left_column),
+                                event.y - (config_state->view_current->top_left.y - config_state->view_current->top_row)};
+               ce_set_cursor(config_state->view_current->buffer_node->buffer,
+                             &config_state->view_current->cursor,
+                             &click);
+          }
+#ifdef SCROLL_SUPPORT
+          // This feature is currently unreliable and is only known to work for Ryan :)
+          else if(event.bstate & (BUTTON_ALT | BUTTON2_CLICKED)){
+               Point next_line = {0, cursor->y + SCROLL_LINES};
+               if(ce_point_on_buffer(buffer, &next_line)){
+                    Point scroll_location = {0, buffer_view->top_row + SCROLL_LINES};
+                    scroll_view_to_location(buffer_view, &scroll_location);
+                    if(buffer_view->cursor.y < buffer_view->top_row)
+                         ce_move_cursor(buffer, cursor, (Point){0, SCROLL_LINES});
+               }
+          }else if(event.bstate & BUTTON4_TRIPLE_CLICKED){
+               Point next_line = {0, cursor->y - SCROLL_LINES};
+               if(ce_point_on_buffer(buffer, &next_line)){
+                    Point scroll_location = {0, buffer_view->top_row - SCROLL_LINES};
+                    scroll_view_to_location(buffer_view, &scroll_location);
+                    if(buffer_view->cursor.y > buffer_view->top_row + (buffer_view->bottom_right.y - buffer_view->top_left.y))
+                         ce_move_cursor(buffer, cursor, (Point){0, -SCROLL_LINES});
+               }
+          }
+#else
+          (void) buffer;
+          (void) buffer_view;
+          (void) cursor;
 #endif
      }
 }

--- a/ce_config.c
+++ b/ce_config.c
@@ -1242,6 +1242,7 @@ bool key_handler(int key, BufferNode* head, void* user_data)
                          }
                     }
                }
+               break;
           case KEY_DC:
                ce_remove_char(buffer, cursor);
                break;

--- a/ce_config.c
+++ b/ce_config.c
@@ -862,6 +862,16 @@ bool key_handler(int key, BufferNode* head, void* user_data)
                // when we exit insert mode, do not move the cursor back unless we are at the end of the line
                *cursor = end_cursor;
           } break;
+          case KEY_MOUSE:
+          {
+               MEVENT event;
+               if(getmouse(&event) == OK){
+                    if(event.bstate & BUTTON1_PRESSED){
+                         Point click = {event.x, event.y};
+                         ce_set_cursor(buffer, cursor, &click);
+                    }
+               }
+          } break;
           case KEY_BACKSPACE:
                if(buffer->line_count){
                     if(cursor->x <= 0){
@@ -1087,6 +1097,16 @@ bool key_handler(int key, BufferNode* head, void* user_data)
           } break;
           case 'q':
                return false; // exit !
+          case KEY_MOUSE:
+          {
+               MEVENT event;
+               if(getmouse(&event) == OK){
+                    if(event.bstate & BUTTON1_PRESSED){
+                         Point click = {event.x, event.y};
+                         ce_set_cursor(buffer, cursor, &click);
+                    }
+               }
+          } break;
           case 'J':
           {
                if(cursor->y == buffer->line_count - 1) break; // nothing to join

--- a/ce_config.c
+++ b/ce_config.c
@@ -8,6 +8,7 @@
 #include <unistd.h>
 
 #define TAB_STRING "     "
+#define SCROLL_LINES 1
 
 static const char* cmd_buffer_name = "shell_command";
 
@@ -880,9 +881,26 @@ bool key_handler(int key, BufferNode* head, void* user_data)
                          ce_set_cursor(config_state->view_current->buffer_node->buffer,
                                        &config_state->view_current->cursor,
                                        &click);
+                    }else if(event.bstate & (REPORT_MOUSE_POSITION | BUTTON2_PRESSED)){
+                         Point next_line = {0, cursor->y + SCROLL_LINES};
+                         if(ce_point_on_buffer(buffer, &next_line)){
+                              Point scroll_location = {0, buffer_view->top_row + SCROLL_LINES};
+                              scroll_view_to_location(buffer_view, &scroll_location);
+                              if(buffer_view->cursor.y < buffer_view->top_row)
+                                   ce_move_cursor(buffer, cursor, (Point){0, SCROLL_LINES});
+                         }
+                    }else if(event.bstate & BUTTON4_PRESSED){
+                         Point next_line = {0, cursor->y - SCROLL_LINES};
+                         if(ce_point_on_buffer(buffer, &next_line)){
+                              Point scroll_location = {0, buffer_view->top_row - SCROLL_LINES};
+                              scroll_view_to_location(buffer_view, &scroll_location);
+                              if(buffer_view->cursor.y > buffer_view->top_row + (buffer_view->bottom_right.y - buffer_view->top_left.y))
+                                   ce_move_cursor(buffer, cursor, (Point){0, -SCROLL_LINES});
+                         }
                     }
                }
           } break;
+          case 127: // keypad unable to map
           case KEY_BACKSPACE:
                if(buffer->line_count){
                     if(cursor->x <= 0){
@@ -913,8 +931,8 @@ bool key_handler(int key, BufferNode* head, void* user_data)
                          }
                     }
                }
-          case 126: // delete ?
-               //ce_remove_char(buffer, cursor);
+          case KEY_DC:
+               ce_remove_char(buffer, cursor);
                break;
           case '\t':
           {
@@ -1118,10 +1136,22 @@ bool key_handler(int key, BufferNode* head, void* user_data)
                          ce_set_cursor(config_state->view_current->buffer_node->buffer,
                                        &config_state->view_current->cursor,
                                        &click);
-                    }else if(event.bstate & REPORT_MOUSE_POSITION){
-                         Point scroll_location = {0, buffer_view->top_row + 1};
-                         scroll_view_to_location(buffer_view, &scroll_location);
-                         if(buffer_view->cursor.y <= buffer_view->top_row) buffer_view->cursor.y++;
+                    }else if(event.bstate & (REPORT_MOUSE_POSITION | BUTTON2_PRESSED)){
+                         Point next_line = {0, cursor->y + SCROLL_LINES};
+                         if(ce_point_on_buffer(buffer, &next_line)){
+                              Point scroll_location = {0, buffer_view->top_row + SCROLL_LINES};
+                              scroll_view_to_location(buffer_view, &scroll_location);
+                              if(buffer_view->cursor.y < buffer_view->top_row)
+                                   ce_move_cursor(buffer, cursor, (Point){0, SCROLL_LINES});
+                         }
+                    }else if(event.bstate & BUTTON4_PRESSED){
+                         Point next_line = {0, cursor->y - SCROLL_LINES};
+                         if(ce_point_on_buffer(buffer, &next_line)){
+                              Point scroll_location = {0, buffer_view->top_row - SCROLL_LINES};
+                              scroll_view_to_location(buffer_view, &scroll_location);
+                              if(buffer_view->cursor.y > buffer_view->top_row + (buffer_view->bottom_right.y - buffer_view->top_left.y))
+                                   ce_move_cursor(buffer, cursor, (Point){0, -SCROLL_LINES});
+                         }
                     }
                }
           } break;

--- a/ce_config.c
+++ b/ce_config.c
@@ -1054,6 +1054,97 @@ void split_view(BufferView* head_view, BufferView* current_view, bool horizontal
      }
 }
 
+void handle_mouse_event(ConfigState* config_state, Buffer* buffer, BufferView* buffer_view, Point* cursor)
+{
+     MEVENT event;
+     if(getmouse(&event) == OK){
+#ifndef MOUSE_DIAG
+          if(event.bstate & BUTTON1_PRESSED){ // Left click OSX
+               Point click = {event.x, event.y};
+               config_state->view_current = ce_find_view_at_point(config_state->view_head, &click);
+               click = (Point) {event.x - (config_state->view_current->top_left.x - config_state->view_current->left_column),
+                                event.y - (config_state->view_current->top_left.y - config_state->view_current->top_row)};
+               ce_set_cursor(config_state->view_current->buffer_node->buffer,
+                             &config_state->view_current->cursor,
+                             &click);
+          }else if(event.bstate & (REPORT_MOUSE_POSITION | BUTTON2_PRESSED)){ // Scroll down OSX (alternates between these two flags)
+               Point next_line = {0, cursor->y + SCROLL_LINES};
+               if(ce_point_on_buffer(buffer, &next_line)){
+                    Point scroll_location = {0, buffer_view->top_row + SCROLL_LINES};
+                    scroll_view_to_location(buffer_view, &scroll_location);
+                    if(buffer_view->cursor.y < buffer_view->top_row)
+                         ce_move_cursor(buffer, cursor, (Point){0, SCROLL_LINES});
+               }
+          }else if(event.bstate & BUTTON4_PRESSED){ // Scroll up OSX
+               Point next_line = {0, cursor->y - SCROLL_LINES};
+               if(ce_point_on_buffer(buffer, &next_line)){
+                    Point scroll_location = {0, buffer_view->top_row - SCROLL_LINES};
+                    scroll_view_to_location(buffer_view, &scroll_location);
+                    if(buffer_view->cursor.y > buffer_view->top_row + (buffer_view->bottom_right.y - buffer_view->top_left.y))
+                         ce_move_cursor(buffer, cursor, (Point){0, -SCROLL_LINES});
+               }
+          }
+#else
+          (void) config_state;
+          (void) buffer;
+          (void) buffer_view;
+          (void) cursor;
+
+          ce_message("0x%x", event.bstate);
+          if(event.bstate & BUTTON1_PRESSED)
+               ce_message("%s", "BUTTON1_PRESSED");
+          else if(event.bstate & BUTTON1_RELEASED)
+               ce_message("%s", "BUTTON1_RELEASED");
+          else if(event.bstate & BUTTON1_CLICKED)
+               ce_message("%s", "BUTTON1_CLICKED");
+          else if(event.bstate & BUTTON1_DOUBLE_CLICKED)
+               ce_message("%s", "BUTTON1_DOUBLE_CLICKED");
+          else if(event.bstate & BUTTON1_TRIPLE_CLICKED)
+               ce_message("%s", "BUTTON1_TRIPLE_CLICKED");
+          else if(event.bstate & BUTTON2_PRESSED)
+               ce_message("%s", "BUTTON2_PRESSED");
+          else if(event.bstate & BUTTON2_RELEASED)
+               ce_message("%s", "BUTTON2_RELEASED");
+          else if(event.bstate & BUTTON2_CLICKED)
+               ce_message("%s", "BUTTON2_CLICKED");
+          else if(event.bstate & BUTTON2_DOUBLE_CLICKED)
+               ce_message("%s", "BUTTON2_DOUBLE_CLICKED");
+          else if(event.bstate & BUTTON2_TRIPLE_CLICKED)
+               ce_message("%s", "BUTTON2_TRIPLE_CLICKED");
+          else if(event.bstate & BUTTON3_PRESSED)
+               ce_message("%s", "BUTTON3_PRESSED");
+          else if(event.bstate & BUTTON3_RELEASED)
+               ce_message("%s", "BUTTON3_RELEASED");
+          else if(event.bstate & BUTTON3_CLICKED)
+               ce_message("%s", "BUTTON3_CLICKED");
+          else if(event.bstate & BUTTON3_DOUBLE_CLICKED)
+               ce_message("%s", "BUTTON3_DOUBLE_CLICKED");
+          else if(event.bstate & BUTTON3_TRIPLE_CLICKED)
+               ce_message("%s", "BUTTON3_TRIPLE_CLICKED");
+          else if(event.bstate & BUTTON4_PRESSED)
+               ce_message("%s", "BUTTON4_PRESSED");
+          else if(event.bstate & BUTTON4_RELEASED)
+               ce_message("%s", "BUTTON4_RELEASED");
+          else if(event.bstate & BUTTON4_CLICKED)
+               ce_message("%s", "BUTTON4_CLICKED");
+          else if(event.bstate & BUTTON4_DOUBLE_CLICKED)
+               ce_message("%s", "BUTTON4_DOUBLE_CLICKED");
+          else if(event.bstate & BUTTON4_TRIPLE_CLICKED)
+               ce_message("%s", "BUTTON4_TRIPLE_CLICKED");
+          else if(event.bstate & BUTTON_SHIFT)
+               ce_message("%s", "BUTTON_SHIFT");
+          else if(event.bstate & BUTTON_CTRL)
+               ce_message("%s", "BUTTON_CTRL");
+          else if(event.bstate & BUTTON_ALT)
+               ce_message("%s", "BUTTON_ALT");
+          else if(event.bstate & REPORT_MOUSE_POSITION)
+               ce_message("%s", "REPORT_MOUSE_POSITION");
+          else if(event.bstate & ALL_MOUSE_EVENTS)
+               ce_message("%s", "ALL_MOUSE_EVENTS");
+#endif
+     }
+}
+
 bool key_handler(int key, BufferNode* head, void* user_data)
 {
      ConfigState* config_state = user_data;
@@ -1118,36 +1209,8 @@ bool key_handler(int key, BufferNode* head, void* user_data)
                *cursor = end_cursor;
           } break;
           case KEY_MOUSE:
-          {
-               MEVENT event;
-               if(getmouse(&event) == OK){
-                    if(event.bstate & BUTTON1_PRESSED){
-                         Point click = {event.x, event.y};
-                         config_state->view_current = ce_find_view_at_point(config_state->view_head, &click);
-                         click = (Point) {event.x - (config_state->view_current->top_left.x - config_state->view_current->left_column),
-                                          event.y - (config_state->view_current->top_left.y - config_state->view_current->top_row)};
-                         ce_set_cursor(config_state->view_current->buffer_node->buffer,
-                                       &config_state->view_current->cursor,
-                                       &click);
-                    }else if(event.bstate & (REPORT_MOUSE_POSITION | BUTTON2_PRESSED)){
-                         Point next_line = {0, cursor->y + SCROLL_LINES};
-                         if(ce_point_on_buffer(buffer, &next_line)){
-                              Point scroll_location = {0, buffer_view->top_row + SCROLL_LINES};
-                              scroll_view_to_location(buffer_view, &scroll_location);
-                              if(buffer_view->cursor.y < buffer_view->top_row)
-                                   ce_move_cursor(buffer, cursor, (Point){0, SCROLL_LINES});
-                         }
-                    }else if(event.bstate & BUTTON4_PRESSED){
-                         Point next_line = {0, cursor->y - SCROLL_LINES};
-                         if(ce_point_on_buffer(buffer, &next_line)){
-                              Point scroll_location = {0, buffer_view->top_row - SCROLL_LINES};
-                              scroll_view_to_location(buffer_view, &scroll_location);
-                              if(buffer_view->cursor.y > buffer_view->top_row + (buffer_view->bottom_right.y - buffer_view->top_left.y))
-                                   ce_move_cursor(buffer, cursor, (Point){0, -SCROLL_LINES});
-                         }
-                    }
-               }
-          } break;
+               handle_mouse_event(config_state, buffer, buffer_view, cursor);
+               break;
           case 127: // keypad unable to map
           case KEY_BACKSPACE:
                if(buffer->line_count){
@@ -1373,36 +1436,8 @@ bool key_handler(int key, BufferNode* head, void* user_data)
                }
           } break;
           case KEY_MOUSE:
-          {
-               MEVENT event;
-               if(getmouse(&event) == OK){
-                    if(event.bstate & BUTTON1_PRESSED){
-                         Point click = {event.x, event.y};
-                         config_state->view_current = ce_find_view_at_point(config_state->view_head, &click);
-                         click = (Point) {event.x - (config_state->view_current->top_left.x - config_state->view_current->left_column),
-                                          event.y - (config_state->view_current->top_left.y - config_state->view_current->top_row)};
-                         ce_set_cursor(config_state->view_current->buffer_node->buffer,
-                                       &config_state->view_current->cursor,
-                                       &click);
-                    }else if(event.bstate & (REPORT_MOUSE_POSITION | BUTTON2_PRESSED)){
-                         Point next_line = {0, cursor->y + SCROLL_LINES};
-                         if(ce_point_on_buffer(buffer, &next_line)){
-                              Point scroll_location = {0, buffer_view->top_row + SCROLL_LINES};
-                              scroll_view_to_location(buffer_view, &scroll_location);
-                              if(buffer_view->cursor.y < buffer_view->top_row)
-                                   ce_move_cursor(buffer, cursor, (Point){0, SCROLL_LINES});
-                         }
-                    }else if(event.bstate & BUTTON4_PRESSED){
-                         Point next_line = {0, cursor->y - SCROLL_LINES};
-                         if(ce_point_on_buffer(buffer, &next_line)){
-                              Point scroll_location = {0, buffer_view->top_row - SCROLL_LINES};
-                              scroll_view_to_location(buffer_view, &scroll_location);
-                              if(buffer_view->cursor.y > buffer_view->top_row + (buffer_view->bottom_right.y - buffer_view->top_left.y))
-                                   ce_move_cursor(buffer, cursor, (Point){0, -SCROLL_LINES});
-                         }
-                    }
-               }
-          } break;
+               handle_mouse_event(config_state, buffer, buffer_view, cursor);
+               break;
           case 'J':
           {
                if(cursor->y == buffer->line_count - 1) break; // nothing to join

--- a/main.c
+++ b/main.c
@@ -230,7 +230,7 @@ int main(int argc, char** argv)
      // ncurses_init()
      initscr();
      keypad(stdscr, TRUE);
-     mousemask(ALL_MOUSE_EVENTS, NULL);
+     mousemask(~0, NULL);
      mouseinterval(0);
      cbreak();
      noecho();

--- a/main.c
+++ b/main.c
@@ -228,8 +228,8 @@ int main(int argc, char** argv)
      }
 
      // ncurses_init()
-     //keypad(initscr(), TRUE); // NOTE: keypad breaks backspace for justin!
      initscr();
+     keypad(stdscr, TRUE);
      cbreak();
      noecho();
 

--- a/main.c
+++ b/main.c
@@ -230,8 +230,9 @@ int main(int argc, char** argv)
      // ncurses_init()
      initscr();
      keypad(stdscr, TRUE);
-     mousemask(~0, NULL);
+     mousemask(~((mmask_t)0), NULL);
      mouseinterval(0);
+     raw();
      cbreak();
      noecho();
 

--- a/main.c
+++ b/main.c
@@ -230,6 +230,8 @@ int main(int argc, char** argv)
      // ncurses_init()
      initscr();
      keypad(stdscr, TRUE);
+     mousemask(ALL_MOUSE_EVENTS, NULL);
+     mouseinterval(0);
      cbreak();
      noecho();
 


### PR DESCRIPTION
KEY_\* enumerations in the curses headers seem to be generated from an OS specific file.  On OSX, ^H seems to be the
typical backspace character, however nowadays terminals send the Linux ^? in order to be compatible with other machines
when SSHing. With keypad off, curses interpets both ^H and ^? as key code 127. With keypad on, the interpretted code
depends on the system specific header. For Justin, backspace (^? on Linux) was being correctly converted to
KEY_BACKSPACE (value 263) by curses, but we were not handling that value in ce_config. For me, backspace (normally ^H on
Mac, but ^? in my case) was unabled to be mapped, and defaulted to value 127 which we were handling in the ce_config as
the backspace operation.

We now look for the KEY_BACKSPACE value when interpreting keys, and I've changed the settings in my terminal to send
^H as backspace. Maybe we should also support the raw 127 value?
